### PR TITLE
Explicitly rename master branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This can be installed with [Conda](https://github.com/conda/conda-docs/blob/mast
     cd <your-project-name>
     git init
     git remote add github git@github.com:lizard-bio/<your-project-name>.git
+    git branch -m main
     git add --all
     git commit -m "first commit"
     git push -f github main


### PR DESCRIPTION
Added a line explicitly renaming the "master" branch to "main". Master is the default name, but this README referred to the "main" branch instead without including the command to change the name.