### PR TITLE
fix: long project names

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -4,7 +4,7 @@ import sys
 
 def validate_lizard_code():
     """if there is a lizard code given, make sure it is in the right format (Liz.X.X)"""
-    MODULE_REGEX = r"^Liz\.[0-9]+\.[0-9]+$"
+    MODULE_REGEX = r"^Liz(\.[0-9]+)+$"
 
     lizard_code = "{{ cookiecutter.lizard_code }}"
     if lizard_code:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -128,3 +128,16 @@ def test_bake_python_and_R_project(cookies):
     check_makefile(path_)
     assert check_author(path_, args["author_name"])
     check_folders(path_, args["use_R"])
+
+
+def test_bake_long_project_code(cookies):
+    args = {
+        "lizard_code": "Liz.10.0.5.5",
+        "project_name": "Microsoft ChatGPT implementation",
+        "author_name": "Ronald Ronalds",
+        "use_R": "yes",
+    }
+
+    result = cookies.bake(template=str(CC_TEMPLATE_ROOT), extra_context=args)
+
+    assert result.exit_code == 0


### PR DESCRIPTION
This commit fixes failing cookiecutter templates (#6) on long lizard codes (f.e. Liz.8.3.2)