### PR TITLE
Add R linter and formatter

### DIFF
--- a/block/r_general/{{ cookiecutter.name }}/.pre-commit-config.yaml
+++ b/block/r_general/{{ cookiecutter.name }}/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: check-added-large-files
+-   repo: https://github.com/etiennebacher/jarl-pre-commit
+    rev: 0.5.0
+    hooks:
+      - id: jarl-check
+-   repo: https://github.com/posit-dev/air-pre-commit
+    # Air version
+    rev: 0.9.0
+    hooks:
+      # Run the formatter
+      - id: air-format

--- a/block/r_general/{{ cookiecutter.name }}/README
+++ b/block/r_general/{{ cookiecutter.name }}/README
@@ -1,6 +1,22 @@
 # {{ cookiecutter.name }}
 
-## Renv
+You should already be in a git repo. Install the R-specific pre-commit hooks
+
+```
+pre-commit install
+```
+
+before doing your first commit.
+
+## Coding conventions
+
+Follow our [R programming style guide](https://www.notion.so/biolizard/R-programming-style-guide-0c2314a846d44bcf8dcdc4e619c53d80)
+
+- Formatting is managed by [air](https://posit-dev.github.io/air/).
+- [Jarl](https://jarl.etiennebacher.com/) is responsible for linting, please
+  install it for optimal experience.
+
+## Managing analysis environments
 
 For the R environment, we use the `renv` package to manage dependencies.
 This is a short how-to.

--- a/block/r_general/{{ cookiecutter.name }}/air.toml
+++ b/block/r_general/{{ cookiecutter.name }}/air.toml
@@ -1,0 +1,11 @@
+[format]
+line-width = 80
+indent-width = 4
+indent-style = "space"
+line-ending = "lf"
+persistent-line-breaks = true
+exclude = []
+default-exclude = true
+skip = []
+table = []
+default-table = true

--- a/block/r_general/{{ cookiecutter.name }}/jarl.toml
+++ b/block/r_general/{{ cookiecutter.name }}/jarl.toml
@@ -1,0 +1,10 @@
+[lint]
+select = [ "PERF", "COMM", "CORR", "READ", "SUSP", "TESTTHAT" ]
+default-exclude = true
+check-roxygen = true
+
+[lint.assignment]
+operator = "<-"
+
+[lint.quotes]
+quote = "double"

--- a/{{ cookiecutter.repo_name }}/environment.yml
+++ b/{{ cookiecutter.repo_name }}/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - openssh=10.2p1
   - python=3.12
   - coverage
   - ruff
@@ -10,3 +11,4 @@ dependencies:
   - pre_commit
   - cookiecutter
   - questionary
+  - air==0.9.0


### PR DESCRIPTION
Fixes https://github.com/lizard-bio/cookiecutter-analytical-project/issues/34

- Added pre-commit hook within the R submodule
- Created air and jarl config files following the internal R style guide
- Adapted README to these changes, also pointing to the R style guide on Notion (to be improved)
- Added air formatter to the conda environment -> maybe this is not always needed, should it be in the R submodule only? How?
- Added openssh to the conda environment, because project.py fails without ssh binary.

Question (@picousse @lpigou ): Why is the feature branch used for submodule template? Shouldn't it be main or some release?

https://github.com/lizard-bio/cookiecutter-analytical-project/blob/7bdb402447184d5149fdd2516e65717cf62002f5/%7B%7B%20cookiecutter.repo_name%20%7D%7D/project.py#L13-L24
